### PR TITLE
ANDROAPP-5631-mobile-ui-integrate-compose-compiler-reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ Button(
     style = ButtonStyle.KEYBOARDKEY
 ) {}
 ```
+
+## Compose Compiler Reports
+
+The Compose Compiler plugin can generate reports / metrics around certain compose-specific concepts that can be useful to understand what is happening with some of your compose code at a fine-grained level.
+You can read more about it [here](https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md).
+
+To generate the reports / metrics, run the following Gradle command
+
+```shell
+./gradlew assembleDebug -PenableComposeCompilerReports=true
+```
+
+This would generate the output at `<module>/build/compose_metrics`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform") apply false
     id("com.android.application") apply false
@@ -12,5 +14,29 @@ allprojects {
         version.set("0.50.0")
         verbose.set(true)
         outputToConsole.set(true)
+    }
+}
+
+subprojects {
+    tasks.withType<KotlinCompilationTask<*>>().configureEach {
+        compilerOptions {
+            // Treat all Kotlin warnings as errors
+            allWarningsAsErrors.set(true)
+
+            if (project.providers.gradleProperty("enableComposeCompilerReports").isPresent) {
+                freeCompilerArgs.addAll(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                        layout.buildDirectory.asFile.get().absolutePath +
+                        "/compose_metrics",
+                )
+                freeCompilerArgs.addAll(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                        layout.buildDirectory.asFile.get().absolutePath +
+                        "/compose_metrics",
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
To generate the reports run `gradle assembleDebug -PenableComposeCompilerReports=true`

Generated reports are in `<module>/build/compose_metrics`
