### PR TITLE
ANDROAPP-5642-mobile-ui-add-search-bar-to-bottom-sheet

### DIFF
--- a/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
+++ b/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
@@ -23,6 +23,7 @@ import org.hisp.dhis.mobile.ui.designsystem.component.ButtonBlock
 import org.hisp.dhis.mobile.ui.designsystem.component.ButtonStyle
 import org.hisp.dhis.mobile.ui.designsystem.component.ColumnComponentContainer
 import org.hisp.dhis.mobile.ui.designsystem.component.LegendRange
+import org.hisp.dhis.mobile.ui.designsystem.component.SearchBar
 import org.hisp.dhis.mobile.ui.designsystem.component.SubTitle
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
@@ -35,6 +36,7 @@ fun BottomSheetScreen() {
     var showBottomSheetShellMaxExpansion by rememberSaveable { mutableStateOf(false) }
     var showBottomSheetShellSingleButton by rememberSaveable { mutableStateOf(false) }
     var showBottomSheetShellTwoButtons by rememberSaveable { mutableStateOf(false) }
+    var showBottomSheetWithSearchBar by rememberSaveable { mutableStateOf(false) }
 
     if (showLegendBottomSheetShell) {
         BottomSheetShell(
@@ -229,6 +231,78 @@ fun BottomSheetScreen() {
         }
     }
 
+    if (showBottomSheetWithSearchBar) {
+        var searchQuery by rememberSaveable { mutableStateOf("") }
+
+        BottomSheetShell(
+            title = "Bottom Sheet with Search Bar",
+            subtitle = "Subtitle",
+            description = lorem,
+            searchBar = { modifier ->
+                SearchBar(
+                    modifier = modifier,
+                    text = searchQuery,
+                    onQueryChange = {
+                        searchQuery = it
+                    },
+                )
+            },
+            buttonBlock = {
+                ButtonBlock(
+                    primaryButton = {
+                        Button(
+                            style = ButtonStyle.OUTLINED,
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Add,
+                                    contentDescription = "Button",
+                                )
+                            },
+                            enabled = true,
+                            text = "Label",
+                            onClick = {
+                                showBottomSheetShellTwoButtons = false
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    },
+                    secondaryButton = {
+                        Button(
+                            style = ButtonStyle.FILLED,
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Add,
+                                    contentDescription = "Button",
+                                )
+                            },
+                            enabled = true,
+                            text = "Label",
+                            onClick = {
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    },
+                )
+            },
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = "Button",
+                    tint = SurfaceColor.Primary,
+                )
+            },
+            content = {
+                Column() {
+                    LegendRange(
+                        regularLegendList,
+                    )
+                }
+            },
+        ) {
+            showBottomSheetShellTwoButtons = false
+        }
+    }
+
     ColumnComponentContainer {
         SubTitle("Legend type bottom sheet shell")
         Button(
@@ -276,6 +350,16 @@ fun BottomSheetScreen() {
             text = "Show Modal",
         ) {
             showBottomSheetShellTwoButtons = !showBottomSheetShellTwoButtons
+        }
+        Spacer(modifier = Modifier.size(Spacing.Spacing10))
+
+        SubTitle("Bottom sheet shell with search bar")
+        Button(
+            enabled = true,
+            ButtonStyle.FILLED,
+            text = "Show Modal",
+        ) {
+            showBottomSheetWithSearchBar = !showBottomSheetWithSearchBar
         }
         Spacer(modifier = Modifier.size(Spacing.Spacing10))
     }

--- a/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
+++ b/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
@@ -23,7 +23,6 @@ import org.hisp.dhis.mobile.ui.designsystem.component.ButtonBlock
 import org.hisp.dhis.mobile.ui.designsystem.component.ButtonStyle
 import org.hisp.dhis.mobile.ui.designsystem.component.ColumnComponentContainer
 import org.hisp.dhis.mobile.ui.designsystem.component.LegendRange
-import org.hisp.dhis.mobile.ui.designsystem.component.SearchBar
 import org.hisp.dhis.mobile.ui.designsystem.component.SubTitle
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
@@ -238,15 +237,6 @@ fun BottomSheetScreen() {
             title = "Bottom Sheet with Search Bar",
             subtitle = "Subtitle",
             description = lorem,
-            searchBar = { modifier ->
-                SearchBar(
-                    modifier = modifier,
-                    text = searchQuery,
-                    onQueryChange = {
-                        searchQuery = it
-                    },
-                )
-            },
             buttonBlock = {
                 ButtonBlock(
                     primaryButton = {
@@ -298,9 +288,13 @@ fun BottomSheetScreen() {
                     )
                 }
             },
-        ) {
-            showBottomSheetShellTwoButtons = false
-        }
+            searchQuery = searchQuery,
+            onSearchQueryChanged = { searchQuery = it },
+            onSearch = { searchQuery = it },
+            onDismiss = {
+                showBottomSheetWithSearchBar = false
+            },
+        )
     }
 
     ColumnComponentContainer {

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -158,18 +158,7 @@ fun BottomSheetShell(
         },
     ) {
         val contentScrollState = rememberScrollState()
-
-        // While the scroll state has `canScrollForward` variable. It's not
-        // working as expected. The max value for the scroll area is fluctuating.
-        // Instead we are getting the initial max value to compare it with
-        // changing value similar to how it's done in `ScrollState`
-        var contentScrollMaxValue by remember { mutableStateOf(0) }
-
-        LaunchedEffect(Unit) {
-            contentScrollMaxValue = contentScrollState.maxValue
-        }
-
-        val canScrollForward by derivedStateOf { contentScrollState.value < (contentScrollMaxValue - Spacing24.value) }
+        val canScrollForward by derivedStateOf { contentScrollState.canScrollForward }
 
         Column {
             Column(

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -93,13 +93,19 @@ fun BottomSheetHeader(
 /**
  * DHIS2 BottomSheetShell. Wraps compose · [ModalBottomSheet].
  * desktop version to be implemented
+ *
+ * Need to override [searchQuery], [onSearchQueryChanged] & [onSearch] in order
+ * to show the search bar. (TODO: We can add lint check for this)
+ *
  * @param title: title to be shown
  * @param subtitle: subTitle to be shown
  * @param description: PopUp description
+ * @param searchQuery: Search query to be displayed in the search bar
  * @param icon: the icon to be shown
- * @param searchBar: dhis searchBar
  * @param buttonBlock: Space for the lower buttons
  * @param content: to be shown under the header
+ * @param onSearchQueryChanged: Callback when search query is changed
+ * @param onSearch: Callback when search action is triggered
  * @param onDismiss: gives access to the onDismiss event
  * @param modifier allows a modifier to be passed externally
  */
@@ -109,11 +115,13 @@ fun BottomSheetShell(
     title: String,
     subtitle: String? = null,
     description: String? = null,
+    searchQuery: String? = null,
     icon: @Composable (() -> Unit)? = null,
-    searchBar: @Composable ((Modifier) -> Unit)? = null,
     buttonBlock: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    onSearchQueryChanged: ((String) -> Unit)? = null,
+    onSearch: ((String) -> Unit)? = null,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(true)
@@ -178,10 +186,15 @@ fun BottomSheetShell(
                         .padding(vertical = Spacing0)
                         .align(Alignment.CenterHorizontally),
                 )
-                searchBar?.invoke(
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = 24.dp),
-                )
+
+                if (searchQuery != null && onSearchQueryChanged != null && onSearch != null) {
+                    SearchBar(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing24),
+                        text = searchQuery.orEmpty(),
+                        onQueryChange = onSearchQueryChanged,
+                        onSearch = onSearch,
+                    )
+                }
                 Divider(
                     modifier = Modifier.fillMaxWidth()
                         .padding(top = Spacing24, start = Spacing24, end = Spacing24),

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -110,7 +110,7 @@ fun BottomSheetShell(
     subtitle: String? = null,
     description: String? = null,
     icon: @Composable (() -> Unit)? = null,
-    searchBar: @Composable (() -> Unit)? = null,
+    searchBar: @Composable ((Modifier) -> Unit)? = null,
     buttonBlock: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
     modifier: Modifier = Modifier,
@@ -178,7 +178,10 @@ fun BottomSheetShell(
                         .padding(vertical = Spacing0)
                         .align(Alignment.CenterHorizontally),
                 )
-                searchBar?.invoke()
+                searchBar?.invoke(
+                    Modifier.fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                )
                 Divider(
                     modifier = Modifier.fillMaxWidth()
                         .padding(top = Spacing24, start = Spacing24, end = Spacing24),

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -20,11 +21,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -69,18 +67,21 @@ fun BottomSheetHeader(
             title,
             style = MaterialTheme.typography.headlineSmall,
             color = TextColor.OnSurface,
-            modifier = Modifier.padding(bottom = Spacing.Spacing4),
         )
+
         subTitle?.let {
+            Spacer(Modifier.requiredHeight(4.dp))
+
             Text(
                 subTitle,
                 style = MaterialTheme.typography.bodySmall,
                 color = TextColor.OnDisabledSurface,
-                modifier = Modifier.padding(bottom = Spacing.Spacing16),
             )
         }
 
         description?.let {
+            Spacer(Modifier.requiredHeight(16.dp))
+
             Text(
                 description,
                 style = MaterialTheme.typography.bodyMedium,
@@ -188,9 +189,11 @@ fun BottomSheetShell(
                 )
 
                 if (searchQuery != null && onSearchQueryChanged != null && onSearch != null) {
+                    Spacer(Modifier.requiredHeight(16.dp))
+
                     SearchBar(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing24),
-                        text = searchQuery.orEmpty(),
+                        text = searchQuery,
                         onQueryChange = onSearchQueryChanged,
                         onSearch = onSearch,
                     )


### PR DESCRIPTION
In order for the search bar to be properly placed as in Figma, we have to control the positioning of it via a modifier. That's why we are sending back the modifier that can be used.

Other option would be to add the search bar inside the bottom sheet it self, but that increases the number of callbacks we need to handle the bottom sheet shell. It's still a valid option to strictly enforce *our* search bar usage rather than passing any composable.
