### PR TITLE
Make title as optional parameter in the bottom sheet component

### DIFF
--- a/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
+++ b/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/BottomSheetScreen.kt
@@ -43,6 +43,7 @@ fun BottomSheetScreen() {
     var showBottomSheetShellSingleButton by rememberSaveable { mutableStateOf(false) }
     var showBottomSheetShellTwoButtons by rememberSaveable { mutableStateOf(false) }
     var showBottomSheetWithSearchBar by rememberSaveable { mutableStateOf(false) }
+    var showBottomSheetWithoutTitle by rememberSaveable { mutableStateOf(false) }
 
     if (showLegendBottomSheetShell) {
         BottomSheetShell(
@@ -309,6 +310,32 @@ fun BottomSheetScreen() {
         )
     }
 
+    if (showBottomSheetWithoutTitle) {
+        var searchQuery by rememberSaveable { mutableStateOf("") }
+
+        BottomSheetShell(
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = "Button",
+                    tint = SurfaceColor.Primary,
+                )
+            },
+            searchQuery = searchQuery,
+            onSearchQueryChanged = { searchQuery = it },
+            onSearch = { searchQuery = it },
+            content = {
+                Column() {
+                    LegendRange(
+                        regularLegendList,
+                    )
+                }
+            },
+        ) {
+            showBottomSheetWithoutTitle = false
+        }
+    }
+
     ColumnComponentContainer {
         SubTitle("Legend type bottom sheet shell")
         Button(
@@ -366,6 +393,16 @@ fun BottomSheetScreen() {
             text = "Show Modal",
         ) {
             showBottomSheetWithSearchBar = !showBottomSheetWithSearchBar
+        }
+        Spacer(modifier = Modifier.size(Spacing.Spacing10))
+
+        SubTitle("Bottom sheet shell without title")
+        Button(
+            enabled = true,
+            ButtonStyle.FILLED,
+            text = "Show Modal",
+        ) {
+            showBottomSheetWithoutTitle = !showBottomSheetWithoutTitle
         }
         Spacer(modifier = Modifier.size(Spacing.Spacing10))
     }

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -119,6 +119,7 @@ fun BottomSheetHeader(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BottomSheetShell(
+    content: @Composable (() -> Unit),
     title: String? = null,
     subtitle: String? = null,
     description: String? = null,
@@ -126,7 +127,6 @@ fun BottomSheetShell(
     contentScrollState: ScrollableState = rememberScrollState(),
     icon: @Composable (() -> Unit)? = null,
     buttonBlock: @Composable (() -> Unit)? = null,
-    content: @Composable (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     onSearchQueryChanged: ((String) -> Unit)? = null,
     onSearch: ((String) -> Unit)? = null,
@@ -222,13 +222,11 @@ fun BottomSheetShell(
                         .then(scrollModifier),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    content?.let {
-                        it.invoke()
-                        Divider(
-                            modifier = Modifier.fillMaxWidth().padding(top = Spacing8),
-                            color = TextColor.OnDisabledSurface,
-                        )
-                    }
+                    content.invoke()
+                    Divider(
+                        modifier = Modifier.fillMaxWidth().padding(top = Spacing8),
+                        color = TextColor.OnDisabledSurface,
+                    )
                 }
             }
 

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -119,7 +119,7 @@ fun BottomSheetHeader(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BottomSheetShell(
-    title: String,
+    title: String? = null,
     subtitle: String? = null,
     description: String? = null,
     searchQuery: String? = null,
@@ -174,20 +174,25 @@ fun BottomSheetShell(
                     .padding(top = Spacing24),
             ) {
                 val hasSearch = searchQuery != null && onSearchQueryChanged != null && onSearch != null
-                BottomSheetHeader(
-                    title,
-                    subtitle,
-                    description,
-                    icon,
-                    hasSearch,
-                    modifier = Modifier
-                        .padding(vertical = Spacing0)
-                        .align(Alignment.CenterHorizontally),
-                )
+                val hasTitle by derivedStateOf { !title.isNullOrBlank() }
+                if (hasTitle) {
+                    BottomSheetHeader(
+                        title!!,
+                        subtitle,
+                        description,
+                        icon,
+                        hasSearch,
+                        modifier = Modifier
+                            .padding(vertical = Spacing0)
+                            .align(Alignment.CenterHorizontally),
+                    )
+                }
+
+                if (hasTitle && hasSearch) {
+                    Spacer(Modifier.requiredHeight(16.dp))
+                }
 
                 if (hasSearch) {
-                    Spacer(Modifier.requiredHeight(16.dp))
-
                     SearchBar(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing24),
                         text = searchQuery!!,
@@ -195,11 +200,14 @@ fun BottomSheetShell(
                         onSearch = onSearch!!,
                     )
                 }
-                Divider(
-                    modifier = Modifier.fillMaxWidth()
-                        .padding(top = Spacing24, start = Spacing24, end = Spacing24),
-                    color = TextColor.OnDisabledSurface,
-                )
+
+                if (hasTitle || hasSearch) {
+                    Divider(
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(top = Spacing24, start = Spacing24, end = Spacing24),
+                        color = TextColor.OnDisabledSurface,
+                    )
+                }
 
                 val scrollModifier = if ((contentScrollState as? ScrollState) != null) {
                     Modifier.verticalScroll(contentScrollState)


### PR DESCRIPTION
Components like org-tree sheet doesn't require a title, so making the title as optional in the bottom sheet component it self.

It didn't made sense to have a bottom sheet component with optional content. Since we always pass content. So, marked it as required as well.