### PR TITLE
Androapp 5893 Fix Org unit selector bottom sheet height

### DIFF
--- a/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/bottomSheets/OrgTreeBottomSheetScreen.kt
+++ b/common/src/commonMain/kotlin/org/hisp/dhis/common/screens/bottomSheets/OrgTreeBottomSheetScreen.kt
@@ -1,5 +1,7 @@
 package org.hisp.dhis.common.screens.bottomSheets
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -7,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,25 +19,93 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.hisp.dhis.common.screens.previews.lorem
 import org.hisp.dhis.common.screens.previews.lorem_medium
+import org.hisp.dhis.common.screens.previews.lorem_short
 import org.hisp.dhis.mobile.ui.designsystem.component.Button
 import org.hisp.dhis.mobile.ui.designsystem.component.ButtonStyle
 import org.hisp.dhis.mobile.ui.designsystem.component.ColumnComponentContainer
 import org.hisp.dhis.mobile.ui.designsystem.component.OrgBottomSheet
 import org.hisp.dhis.mobile.ui.designsystem.component.OrgTreeItem
 import org.hisp.dhis.mobile.ui.designsystem.component.SubTitle
+import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 
 @Composable
 fun OrgTreeBottomSheetScreen() {
-    var showOrgTreeBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var showOneOrgTreeBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var showTwoOrgTreeBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var showMediumOrgTreeBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var showLargeOrgTreeBottomSheet by rememberSaveable { mutableStateOf(false) }
 
-    if (showOrgTreeBottomSheet) {
+    if (showOneOrgTreeBottomSheet) {
         val orgTreeItemsRepo = remember { OrgTreeItemsFakeRepo() }
-        val orgTreeItems by orgTreeItemsRepo.state.collectAsState(emptyList())
+        val oneOrgTreeItem by orgTreeItemsRepo.state.collectAsState(emptyList())
 
         OrgBottomSheet(
-            orgTreeItems = orgTreeItems,
+            orgTreeItems = oneOrgTreeItem.take(1),
             onDismiss = {
-                showOrgTreeBottomSheet = false
+                showOneOrgTreeBottomSheet = false
+            },
+            onSearch = orgTreeItemsRepo::search,
+            onItemClick = orgTreeItemsRepo::toggleItemExpansion,
+            onItemSelected = { uid, checked ->
+                orgTreeItemsRepo.toggleItemSelection(uid, checked)
+            },
+            onClearAll = { orgTreeItemsRepo.clearItemSelections() },
+            onDone = {
+                // no-op
+            },
+        )
+    }
+
+    if (showTwoOrgTreeBottomSheet) {
+        val orgTreeItemsRepo = remember { OrgTreeItemsFakeRepo() }
+        val oneOrgTreeItem by orgTreeItemsRepo.state.collectAsState(emptyList())
+
+        OrgBottomSheet(
+            orgTreeItems = oneOrgTreeItem.take(4),
+            onDismiss = {
+                showTwoOrgTreeBottomSheet = false
+            },
+            onSearch = orgTreeItemsRepo::search,
+            onItemClick = orgTreeItemsRepo::toggleItemExpansion,
+            onItemSelected = { uid, checked ->
+                orgTreeItemsRepo.toggleItemSelection(uid, checked)
+            },
+            onClearAll = { orgTreeItemsRepo.clearItemSelections() },
+            onDone = {
+                // no-op
+            },
+        )
+    }
+
+    if (showMediumOrgTreeBottomSheet) {
+        val orgTreeItemsRepo = remember { OrgTreeItemsFakeRepo() }
+        val oneOrgTreeItem by orgTreeItemsRepo.state.collectAsState(emptyList())
+
+        OrgBottomSheet(
+            orgTreeItems = oneOrgTreeItem.take(8),
+            onDismiss = {
+                showMediumOrgTreeBottomSheet = false
+            },
+            onSearch = orgTreeItemsRepo::search,
+            onItemClick = orgTreeItemsRepo::toggleItemExpansion,
+            onItemSelected = { uid, checked ->
+                orgTreeItemsRepo.toggleItemSelection(uid, checked)
+            },
+            onClearAll = { orgTreeItemsRepo.clearItemSelections() },
+            onDone = {
+                // no-op
+            },
+        )
+    }
+
+    if (showLargeOrgTreeBottomSheet) {
+        val orgTreeItemsRepo = remember { OrgTreeItemsFakeRepo() }
+        val oneOrgTreeItem by orgTreeItemsRepo.state.collectAsState(emptyList())
+
+        OrgBottomSheet(
+            orgTreeItems = oneOrgTreeItem,
+            onDismiss = {
+                showLargeOrgTreeBottomSheet = false
             },
             onSearch = orgTreeItemsRepo::search,
             onItemClick = orgTreeItemsRepo::toggleItemExpansion,
@@ -53,9 +124,39 @@ fun OrgTreeBottomSheetScreen() {
         Button(
             enabled = true,
             ButtonStyle.FILLED,
+            text = "Show One Org Tree Bottom Sheet",
+        ) {
+            showOneOrgTreeBottomSheet = !showOneOrgTreeBottomSheet
+        }
+        Spacer(modifier = Modifier.size(Spacing.Spacing10))
+
+        SubTitle("Org Tree Bottom Sheet")
+        Button(
+            enabled = true,
+            ButtonStyle.FILLED,
+            text = "Show Two Org Tree Bottom Sheet",
+        ) {
+            showTwoOrgTreeBottomSheet = !showTwoOrgTreeBottomSheet
+        }
+        Spacer(modifier = Modifier.size(Spacing.Spacing10))
+
+        SubTitle("Org Tree Bottom Sheet")
+        Button(
+            enabled = true,
+            ButtonStyle.FILLED,
             text = "Show Org Tree Bottom Sheet",
         ) {
-            showOrgTreeBottomSheet = !showOrgTreeBottomSheet
+            showMediumOrgTreeBottomSheet = !showMediumOrgTreeBottomSheet
+        }
+        Spacer(modifier = Modifier.size(Spacing.Spacing10))
+
+        SubTitle("Org Tree Bottom Sheet")
+        Button(
+            enabled = true,
+            ButtonStyle.FILLED,
+            text = "Show Large Org Tree Bottom Sheet",
+        ) {
+            showLargeOrgTreeBottomSheet = !showLargeOrgTreeBottomSheet
         }
     }
 }
@@ -87,7 +188,30 @@ private class OrgTreeItemsFakeRepo {
             isOpen = false,
             hasChildren = false,
         ),
-
+        OrgTreeItem(
+            uid = "51",
+            label = "UHC Alphabet",
+            isOpen = false,
+            hasChildren = false,
+        ),
+        OrgTreeItem(
+            uid = "61",
+            label = lorem_short,
+            isOpen = false,
+            hasChildren = false,
+        ),
+        OrgTreeItem(
+            uid = "71",
+            label = "UHC TEST 1",
+            isOpen = false,
+            hasChildren = false,
+        ),
+        OrgTreeItem(
+            uid = "81",
+            label = "UHC TEST 2",
+            isOpen = false,
+            hasChildren = false,
+        ),
     )
 
     private val childrenOrgItems = listOf(
@@ -173,6 +297,7 @@ private class OrgTreeItemsFakeRepo {
                         val selectedChildrenCount = getSelectedChildrenCount(selectionToggledList, it)
                         it.copy(selectedChildrenCount = selectedChildrenCount)
                     }
+
                     else -> {
                         it.copy(selectedChildrenCount = 0)
                     }

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.hisp.dhis.mobile.ui.designsystem.component.internal.Keyboard
@@ -145,6 +146,8 @@ fun BottomSheetHeader(
  * @param onDismiss: gives access to the onDismiss event.
  * @param modifier allows a modifier to be passed externally.
  * @param headerTextAlignment [Alignment] for header text.
+ * @param scrollableContainerMinHeight: Min size for scrollable content.
+ * @param scrollableContainerMaxHeight: Max size for scrollable content.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -160,6 +163,8 @@ fun BottomSheetShell(
     buttonBlock: @Composable (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     headerTextAlignment: TextAlign = TextAlign.Center,
+    scrollableContainerMinHeight: Dp = Spacing0,
+    scrollableContainerMaxHeight: Dp = InternalSizeValues.Size386,
     onSearchQueryChanged: ((String) -> Unit)? = null,
     onSearch: ((String) -> Unit)? = null,
     onDismiss: () -> Unit,
@@ -267,7 +272,7 @@ fun BottomSheetShell(
                     Column(
                         modifier = Modifier
                             .padding(horizontal = Spacing24)
-                            .heightIn(Spacing0, InternalSizeValues.Size386)
+                            .heightIn(scrollableContainerMinHeight, scrollableContainerMaxHeight)
                             .then(scrollModifier),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -277,6 +277,7 @@ fun BottomSheetShell(
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         content.invoke()
+                        Spacer(modifier = Modifier.weight(1f))
                         if (showSectionDivider) {
                             HorizontalDivider(
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing8),

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,7 +27,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,11 +47,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import org.hisp.dhis.mobile.ui.designsystem.component.internal.Keyboard
-import org.hisp.dhis.mobile.ui.designsystem.component.internal.keyboardAsState
+import androidx.compose.ui.unit.max
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideDHIS2Icon
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
 import org.hisp.dhis.mobile.ui.designsystem.theme.DHIS2SCustomTextStyles
+import org.hisp.dhis.mobile.ui.designsystem.theme.InternalSizeValues
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
@@ -98,16 +97,6 @@ fun OrgBottomSheet(
     var searchQuery by remember { mutableStateOf("") }
     var orgTreeHeight by remember { mutableStateOf(0) }
     val orgTreeHeightInDp = with(LocalDensity.current) { orgTreeHeight.toDp() }
-    val keyboardState by keyboardAsState()
-
-    var isKeyboardOpen by remember { mutableStateOf(false) }
-
-    LaunchedEffect(keyboardState) {
-        isKeyboardOpen = keyboardState == Keyboard.Opened
-        if (isKeyboardOpen) {
-            listState.scrollToItem(0)
-        }
-    }
 
     BottomSheetShell(
         modifier = modifier,
@@ -137,7 +126,9 @@ fun OrgBottomSheet(
                             orgTreeHeight = treeHeight
                         }
                     }
-                    .requiredHeightIn(min = if (isKeyboardOpen) Spacing.Spacing0 else orgTreeHeightInDp),
+                    .heightIn(
+                        max(orgTreeHeightInDp, InternalSizeValues.Size386)
+                    ),
             )
         },
         buttonBlock = {
@@ -194,8 +185,8 @@ private fun OrgTreeList(
         Text(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(top = Spacing.Spacing24, bottom = Spacing.Spacing96)
-                .padding(horizontal = Spacing.Spacing16)
+                .padding(horizontal = Spacing.Spacing24)
+                .padding(vertical = Spacing.Spacing24)
                 .testTag("ORG_TREE_NO_RESULTS_FOUND"),
             textAlign = TextAlign.Center,
             text = noResultsFoundText,

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideDHIS2Icon
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
 import org.hisp.dhis.mobile.ui.designsystem.theme.DHIS2SCustomTextStyles
@@ -93,7 +92,6 @@ fun OrgBottomSheet(
     onClearAll: () -> Unit,
     onDone: () -> Unit,
 ) {
-    val listState = rememberLazyListState()
     var searchQuery by remember { mutableStateOf("") }
     var orgTreeHeight by remember { mutableStateOf(0) }
     val orgTreeHeightInDp = with(LocalDensity.current) { orgTreeHeight.toDp() }
@@ -110,10 +108,10 @@ fun OrgBottomSheet(
             onSearch?.invoke(searchQuery)
         },
         onSearch = onSearch,
-        contentScrollState = listState,
+        scrollableContainerMinHeight = InternalSizeValues.Size386,
+        scrollableContainerMaxHeight = maxOf(orgTreeHeightInDp, InternalSizeValues.Size386),
         content = {
             OrgTreeList(
-                state = listState,
                 orgTreeItems = orgTreeItems,
                 searchQuery = searchQuery,
                 noResultsFoundText = noResultsFoundText,
@@ -126,9 +124,6 @@ fun OrgBottomSheet(
                             orgTreeHeight = treeHeight
                         }
                     }
-                    .heightIn(
-                        max(orgTreeHeightInDp, InternalSizeValues.Size386)
-                    ),
             )
         },
         buttonBlock = {
@@ -171,7 +166,6 @@ fun OrgBottomSheet(
 
 @Composable
 private fun OrgTreeList(
-    state: LazyListState,
     orgTreeItems: List<OrgTreeItem>,
     searchQuery: String,
     noResultsFoundText: String,
@@ -194,15 +188,14 @@ private fun OrgTreeList(
             style = MaterialTheme.typography.bodyMedium,
         )
     } else {
-        LazyColumn(
+        Column(
             modifier = modifier
                 .fillMaxWidth()
                 .testTag("ORG_TREE_LIST")
                 .horizontalScroll(scrollState),
-            state = state,
             horizontalAlignment = Alignment.Start,
         ) {
-            items(orgTreeItems) { item ->
+            orgTreeItems.forEach { item ->
                 OrgUnitSelectorItem(
                     orgTreeItem = item,
                     higherLevel = orgTreeItems.minBy { it.level }.level,

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
@@ -11,10 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -123,7 +119,7 @@ fun OrgBottomSheet(
                         if (treeHeight > orgTreeHeight) {
                             orgTreeHeight = treeHeight
                         }
-                    }
+                    },
             )
         },
         buttonBlock = {

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/theme/Spacing.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/theme/Spacing.kt
@@ -23,7 +23,6 @@ object Spacing {
     val Spacing72: Dp = 72.dp
     val Spacing80: Dp = 80.dp
     val Spacing88: Dp = 88.dp
-    val Spacing96: Dp = 96.dp
     val Spacing104: Dp = 104.dp
     val Spacing416: Dp = 416.dp
     val Spacing112: Dp = 112.dp


### PR DESCRIPTION
Fix includes:

1. Size of bottom sheet when there are less items or `No Results Found`.
2. Fix the alignment of bottom divider