### PR TITLE
ANDROAPP-6522-mobile-ui-checkbox-briefly-appears-selected-during-the-org-unit-tree-collapse-animation

### DIFF
--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -199,13 +200,15 @@ private fun OrgTreeList(
             horizontalAlignment = Alignment.Start,
         ) {
             orgTreeItems.forEach { item ->
-                OrgUnitSelectorItem(
-                    orgTreeItem = item,
-                    higherLevel = orgTreeItems.minBy { it.level }.level,
-                    searchQuery = searchQuery,
-                    onItemClick = onItemClick,
-                    onItemSelected = onItemSelected,
-                )
+                key(item.uid) {
+                    OrgUnitSelectorItem(
+                        orgTreeItem = item,
+                        higherLevel = orgTreeItems.minBy { it.level }.level,
+                        searchQuery = searchQuery,
+                        onItemClick = onItemClick,
+                        onItemSelected = onItemSelected,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Wrap `OrgUnitSelectorItem` in a `key`

This acts same as item key in lazy views. Prevents the composable from recomposing unnecessarily when the key didn't change in the control flows. Like in this `forLoop` for example.
