### PR TITLE
chore: Sonatype central portal

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Publish to maven
         run: ./.github/workflows/scripts/publish-maven.sh
         env:
-          OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
           SIGNING_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,14 +85,16 @@ subprojects {
     }
 }
 
-val ossrhUsername: String? = System.getenv("OSSRH_USERNAME")
-val ossrhPassword: String? = System.getenv("OSSRH_PASSWORD")
+val centralPortalUsername: String? = System.getenv("SONATYPE_USERNAME")
+val centralPortalPassword: String? = System.getenv("SONATYPE_PASSWORD")
 
 nexusPublishing {
     this.repositories {
         sonatype {
-            username.set(ossrhUsername)
-            password.set(ossrhPassword)
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(centralPortalUsername)
+            password.set(centralPortalPassword)
         }
     }
 }

--- a/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
@@ -3,8 +3,6 @@ plugins {
     signing
 }
 
-val ossrhUsername: String? = System.getenv("OSSRH_USERNAME")
-val ossrhPassword: String? = System.getenv("OSSRH_PASSWORD")
 val signingPrivateKey: String? = System.getenv("SIGNING_PRIVATE_KEY")
 val signingPassword: String? = System.getenv("SIGNING_PASSWORD")
 


### PR DESCRIPTION
This PR adapts the publishing service to use the new Central Publisher Portal.