### PR TITLE
fix: [ANDROAPP-7125] BottomSheet component handles edge to edge lower padding 

### DIFF
--- a/designsystem/src/androidMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.android.kt
+++ b/designsystem/src/androidMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.android.kt
@@ -1,0 +1,13 @@
+package org.hisp.dhis.mobile.ui.designsystem.component.state
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+
+@Composable
+internal actual fun safeLowerPadding(): Dp {
+    val navInsets = WindowInsets.navigationBars
+    return navInsets.asPaddingValues().calculateBottomPadding()
+}

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/BottomSheet.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.hisp.dhis.mobile.ui.designsystem.component.internal.Keyboard
 import org.hisp.dhis.mobile.ui.designsystem.component.internal.keyboardAsState
+import org.hisp.dhis.mobile.ui.designsystem.component.state.BottomSheetShellDefaults
 import org.hisp.dhis.mobile.ui.designsystem.component.state.BottomSheetShellUIState
 import org.hisp.dhis.mobile.ui.designsystem.theme.Border
 import org.hisp.dhis.mobile.ui.designsystem.theme.InternalSizeValues
@@ -73,9 +74,7 @@ fun BottomSheetHeader(
     title: String,
     subTitle: String? = null,
     description: String? = null,
-    icon:
-        @Composable
-        (() -> Unit)? = null,
+    icon: @Composable (() -> Unit)? = null,
     hasSearch: Boolean = false,
     headerTextAlignment: TextAlign = TextAlign.Center,
     modifier: Modifier = Modifier,
@@ -422,7 +421,7 @@ fun BottomSheetShell(
             buttonBlock?.let {
                 buttonBlock.invoke()
             }
-            Spacer(Modifier.requiredHeight(uiState.bottomPadding))
+            Spacer(Modifier.requiredHeight(BottomSheetShellDefaults.safePadding()))
         }
     }
 }

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputDropDown.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputDropDown.kt
@@ -83,7 +83,6 @@ private const val MAX_DROPDOWN_ITEMS_TO_SHOW = 50
  * @param useDropDown: use dropdown if true. Bottomsheet with search capability otherwise.
  * @param onDismiss: gives access to the onDismiss event.
  * @param windowInsets: The insets to use for the bottom sheet shell.
- * @param bottomSheetLowerPadding the lower padding to use for the bottom sheet
  * @param noResultsFoundString: text to be shown in pop up when no results are found.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -109,7 +108,6 @@ fun InputDropDown(
     loadOptions: () -> Unit,
     onDismiss: () -> Unit = {},
     windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-    bottomSheetLowerPadding: Dp = Spacing0,
     noResultsFoundString: String = provideStringResource("no_results_found"),
     searchToFindMoreString: String = provideStringResource("search_to_see_more"),
 ) {
@@ -150,7 +148,6 @@ fun InputDropDown(
                         BottomSheetShellUIState(
                             showBottomSectionDivider = true,
                             showTopSectionDivider = true,
-                            bottomPadding = bottomSheetLowerPadding,
                             title = title,
                             searchQuery =
                                 if (showSearchBar) {

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputMultiSelection.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputMultiSelection.kt
@@ -250,7 +250,6 @@ fun InputMultiSelection(
         if (showMultiSelectBottomSheet) {
             MultiSelectBottomSheet(
                 windowInsets = windowInsets,
-                bottomSheetLowerPadding = bottomSheetLowerPadding,
                 items = items,
                 title = title,
                 maxItemsToShow = maxItemsToShow,
@@ -306,7 +305,6 @@ fun MultiSelectBottomSheet(
     searchToFindMoreString: String,
     doneButtonText: String,
     windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-    bottomSheetLowerPadding: Dp = Spacing0,
     onItemsSelected: (List<CheckBoxData>) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -323,7 +321,6 @@ fun MultiSelectBottomSheet(
         uiState =
             BottomSheetShellUIState(
                 title = title,
-                bottomPadding = bottomSheetLowerPadding,
                 searchQuery = searchQuery,
             ),
         modifier = Modifier.testTag("INPUT_MULTI_SELECT_BOTTOM_SHEET"),

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputSignature.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/InputSignature.kt
@@ -13,10 +13,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.unit.Dp
 import org.hisp.dhis.mobile.ui.designsystem.component.internal.signature.SignatureBottomSheet
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
-import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
 
 /**
  * DHIS2 Input signature. Wraps DHIS · [BasicInputImage].
@@ -24,7 +22,6 @@ import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
  * @param state: manages the InputShell state.
  * @param inputStyle: manages the InputShell style.
  * @param windowInsets: the insets for the bottom sheet shell.
- * @param bottomSheetLowerPadding the padding for the bottom sheet shell.
  * @param supportingText: is a list of SupportingTextData that.
  * manages all the messages to be shown.
  * @param legendData: manages the legendComponent.
@@ -47,7 +44,6 @@ fun <T> InputSignature(
     state: InputShellState = InputShellState.UNFOCUSED,
     inputStyle: InputStyle = InputStyle.DataInputStyle(),
     windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-    bottomSheetLowerPadding: Dp = Spacing0,
     supportingText: List<SupportingTextData>? = null,
     legendData: LegendData? = null,
     addSignatureBtnText: String = provideStringResource("add_signature"),
@@ -97,7 +93,6 @@ fun <T> InputSignature(
                 showBottomSheet = false
             },
             windowInsets = windowInsets,
-            bottomSheetLowerPadding = bottomSheetLowerPadding,
         )
     }
 }

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/Legend.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/Legend.kt
@@ -35,12 +35,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.Dp
 import org.hisp.dhis.mobile.ui.designsystem.component.state.BottomSheetShellUIState
 import org.hisp.dhis.mobile.ui.designsystem.theme.Border
 import org.hisp.dhis.mobile.ui.designsystem.theme.InternalSizeValues
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
-import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.hoverPointerIcon
 
@@ -136,7 +134,6 @@ fun Legend(
             uiState =
                 BottomSheetShellUIState(
                     title = legendData.title,
-                    bottomPadding = legendData.bottomSheetLowerPadding,
                 ),
             modifier = Modifier.testTag("LEGEND_BOTTOM_SHEET"),
             content = {
@@ -247,5 +244,4 @@ data class LegendData
         val title: String,
         val popUpLegendDescriptionData: List<LegendDescriptionData>? = null,
         val windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-        val bottomSheetLowerPadding: Dp = Spacing0,
     )

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/OrgBottomSheet.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.mobile.ui.designsystem.component.state.BottomSheetShellDefaults
 import org.hisp.dhis.mobile.ui.designsystem.component.state.BottomSheetShellUIState
@@ -58,7 +57,6 @@ import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
 import org.hisp.dhis.mobile.ui.designsystem.theme.DHIS2SCustomTextStyles
 import org.hisp.dhis.mobile.ui.designsystem.theme.InternalSizeValues
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
-import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
 
@@ -73,7 +71,6 @@ import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
  * @param doneButtonText text for accept button.
  * @param doneButtonIcon icon for accept button.
  * @param windowInsets The insets to use for the bottom sheet shell.
- * @param bottomSheetLowerPadding padding for the bottom sheet.
  * @param noResultsFoundText text for no results found.
  * @param headerTextAlignment [Alignment] for header text.
  * @param icon optional icon to be shown above the header .
@@ -97,7 +94,6 @@ fun OrgBottomSheet(
     doneButtonText: String? = null,
     doneButtonIcon: ImageVector = Icons.Filled.Check,
     windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-    bottomSheetLowerPadding: Dp = Spacing0,
     noResultsFoundText: String = provideStringResource("no_results_found"),
     headerTextAlignment: TextAlign = TextAlign.Center,
     icon: @Composable (() -> Unit)? = null,
@@ -129,7 +125,6 @@ fun OrgBottomSheet(
                 searchQuery = searchQuery,
                 scrollableContainerMaxHeight = maxOf(orgTreeHeightInDp, InternalSizeValues.Size386),
                 scrollableContainerMinHeight = InternalSizeValues.Size186,
-                bottomPadding = bottomSheetLowerPadding,
             ),
         modifier = modifier,
         contentScrollState = contentScrollState,

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/internal/signature/SignatureBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/internal/signature/SignatureBottomSheet.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.mobile.ui.designsystem.component.BottomSheetShell
 import org.hisp.dhis.mobile.ui.designsystem.component.Button
@@ -40,7 +39,6 @@ import org.hisp.dhis.mobile.ui.designsystem.theme.Border
 import org.hisp.dhis.mobile.ui.designsystem.theme.Color
 import org.hisp.dhis.mobile.ui.designsystem.theme.Radius
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
-import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
 
@@ -51,7 +49,6 @@ internal fun SignatureBottomSheet(
     drawHereText: String = provideStringResource("draw_here"),
     resetButtonText: String = provideStringResource("reset"),
     doneButtonText: String = provideStringResource("done"),
-    bottomSheetLowerPadding: Dp = Spacing0,
     windowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     onDismiss: () -> Unit,
     onSave: (ImageBitmap) -> Unit,
@@ -64,7 +61,6 @@ internal fun SignatureBottomSheet(
             BottomSheetShellUIState(
                 title = title,
                 showTopSectionDivider = false,
-                bottomPadding = bottomSheetLowerPadding,
             ),
         modifier = Modifier.testTag("INPUT_SIGNATURE_BOTTOM_SHEET"),
         content = {

--- a/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.kt
+++ b/designsystem/src/commonMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import org.hisp.dhis.mobile.ui.designsystem.theme.InternalSizeValues
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing0
-import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing16
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing24
 
 /**
@@ -21,7 +20,6 @@ import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing.Spacing24
  * @property searchQuery The search query to be displayed in the search bar.
  * @property showTopSectionDivider Whether to show the top section divider.
  * @property showBottomSectionDivider Whether to show the bottom section divider.
- * @property bottomPadding The lower padding for the bottom sheet shell.
  * @property headerTextAlignment The alignment for the header text.
  * @property scrollableContainerMinHeight The minimum height for the scrollable content container.
  * @property scrollableContainerMaxHeight The maximum height for the scrollable content container.
@@ -36,7 +34,6 @@ data class BottomSheetShellUIState(
     val searchQuery: String? = null,
     val showTopSectionDivider: Boolean = true,
     val showBottomSectionDivider: Boolean = true,
-    val bottomPadding: Dp = Spacing0,
     val headerTextAlignment: TextAlign = TextAlign.Center,
     val scrollableContainerMinHeight: Dp = Spacing0,
     val scrollableContainerMaxHeight: Dp = InternalSizeValues.Size386,
@@ -72,11 +69,14 @@ class BottomSheetShellDefaults {
             }
 
         /**
-         * Returns the appropriate lower padding for the BottomSheet based on whether edge-to-edge mode is enabled.
+         * Returns the appropriate lower padding for the BottomSheet based on device's navigation bar height.
          *
-         * @param isEdgeToEdgeEnabled Boolean indicating if edge-to-edge mode is enabled.
          * @return a dp value based on the edge-to-edge mode.
          */
-        fun lowerPadding(isEdgeToEdgeEnabled: Boolean): Dp = if (isEdgeToEdgeEnabled) Spacing16 else Spacing0
+        @Composable
+        fun safePadding() = safeLowerPadding()
     }
 }
+
+@Composable
+internal expect fun safeLowerPadding(): Dp

--- a/designsystem/src/desktopMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.desktop.kt
+++ b/designsystem/src/desktopMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.desktop.kt
@@ -1,0 +1,8 @@
+package org.hisp.dhis.mobile.ui.designsystem.component.state
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal actual fun safeLowerPadding(): Dp = 0.dp

--- a/designsystem/src/iosMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.ios.kt
+++ b/designsystem/src/iosMain/kotlin/org/hisp/dhis/mobile/ui/designsystem/component/state/BottomSheetShellState.ios.kt
@@ -1,0 +1,16 @@
+package org.hisp.dhis.mobile.ui.designsystem.component.state
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import platform.UIKit.UIApplication
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+internal actual fun safeLowerPadding(): Dp {
+    val window = UIApplication.sharedApplication.keyWindow ?: return 0.dp
+    val bottomInset = window.safeAreaInsets.useContents { bottom }
+    return bottomInset.dp
+}

--- a/showcaseApp/src/commonMain/kotlin/org/hisp/dhis/showcaseapp/screens/bottomSheets/BottomSheetScreen.kt
+++ b/showcaseApp/src/commonMain/kotlin/org/hisp/dhis/showcaseapp/screens/bottomSheets/BottomSheetScreen.kt
@@ -177,7 +177,6 @@ fun BottomSheetScreen() {
             uiState =
                 BottomSheetShellUIState(
                     title = "Legend name ",
-                    bottomPadding = BottomSheetShellDefaults.lowerPadding(true),
                     subtitle = "Subtitle",
                     description = LOREM + LOREM,
                 ),

--- a/showcaseApp/src/commonMain/kotlin/org/hisp/dhis/showcaseapp/screens/toggleableInputs/InputDropDownScreen.kt
+++ b/showcaseApp/src/commonMain/kotlin/org/hisp/dhis/showcaseapp/screens/toggleableInputs/InputDropDownScreen.kt
@@ -140,7 +140,6 @@ fun InputDropDownScreen() {
                 loadOptions = {
                     // no-op
                 },
-                bottomSheetLowerPadding = BottomSheetShellDefaults.lowerPadding(isEdgeToEdgeEnabled = true),
                 windowInsets = { BottomSheetShellDefaults.windowInsets(true) },
             )
         }


### PR DESCRIPTION
Introduce platform-specific handling for bottom sheet safe lower padding. Remove `bottomSheetLowerPadding` references for consistency.