### PR TITLE
chore: update dependabot configuration to ignore all development versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    ignore:
+      - dependency-name: "*"
+        versions: [ "*+*" ]
     groups:
       gradle-updates:
         patterns:


### PR DESCRIPTION
Update dependabot to ignore development versions