### PR TITLE
chore: add maven and api docs badges to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DHIS2 Mobile UI
 
+[![Maven Central](https://img.shields.io/maven-central/v/org.hisp.dhis.mobile/designsystem?label=maven%20central)](https://central.sonatype.com/artifact/org.hisp.dhis.mobile/designsystem)
+[![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://dhis2.github.io/dhis2-mobile-ui/api/)
+
 Dhis2 Mobile UI library documentation, installation and usage is explained in [DHIS2 Developer portal](https://developers.dhis2.org/docs/mobile/mobile-ui/overview)
 
 ## Compose Compiler Reports


### PR DESCRIPTION
This PR adds badges at the top of the readme file with the latest published version in maven central and a link to the API documentation of the repository. The badges will be visible on main page of the repository, when rendering the README markdown file.