### PR TITLE
ci: make golden image workflow produce verified commits

### DIFF
--- a/.github/workflows/generate-paparazzi-golden-images.yml
+++ b/.github/workflows/generate-paparazzi-golden-images.yml
@@ -64,42 +64,16 @@ jobs:
           name: paparazzi-golden-images
           path: ${{ env.main_project_module }}/src/androidUnitTest/snapshots/images
 
-      # gh-commit (like dhis2-android-capture-app) commits via the GitHub API, so
-      # the commit is signed with GitHub's web-flow key and counts as Verified --
-      # required because the "Require signed commits" ruleset covers ~ALL branches
-      # with no bypass actors, and a plain push of a bot commit is rejected (GH013).
-      #
-      # The catch: gh-commit reads file contents from the WORKING TREE
-      # (fs.readFileSync). The golden images are LFS-tracked, so the working tree
-      # holds real PNG bytes -- committing those would silently take the images out
-      # of LFS. So upload the LFS objects first, then replace the working-tree files
-      # with their pointer text, which is what actually belongs in the commit.
-      - name: Upload LFS objects and stage pointers
+      # Uploads the LFS objects and leaves pointer text in the working tree, which
+      # is what gh-commit below must read. See the script for why.
+      - name: Stage recorded images as LFS pointers
         if: steps.verify.outcome == 'failure'
-        run: |
-          set -euo pipefail
-          git add -A
-          mapfile -t added < <(git diff --cached --name-only --diff-filter=d)
-          if [ ${#added[@]} -eq 0 ]; then
-            echo "No recorded image changes."
-            exit 0
-          fi
-          # Push the LFS blobs before the pointers land, so the commit is never
-          # left referencing objects the server doesn't have.
-          oids=()
-          for f in "${added[@]}"; do
-            oid=$(git cat-file blob ":$f" | sed -n 's/^oid sha256://p')
-            if [ -n "$oid" ]; then oids+=("$oid"); fi
-          done
-          if [ ${#oids[@]} -gt 0 ]; then
-            git lfs push --object-id origin "${oids[@]}"
-          fi
-          # Hand gh-commit pointers instead of PNGs.
-          for f in "${added[@]}"; do
-            git cat-file blob ":$f" > "$f"
-          done
-          git reset
+        run: .github/workflows/scripts/stage-golden-images.sh
 
+      # Commits via the GitHub API (like dhis2-android-capture-app), so the commit
+      # is signed with GitHub's web-flow key and counts as Verified -- required
+      # because the "Require signed commits" ruleset covers ~ALL branches with no
+      # bypass actors, and a plain push of a bot commit is rejected with GH013.
       - name: Commit golden images
         if: steps.verify.outcome == 'failure'
         uses: flex-development/gh-commit@177be4b5bca1b102400ca7220932d9ff7980fddb

--- a/.github/workflows/generate-paparazzi-golden-images.yml
+++ b/.github/workflows/generate-paparazzi-golden-images.yml
@@ -19,9 +19,10 @@ jobs:
         with:
           lfs: 'true'
           fetch-depth: 0
-          # Credentials are persisted on purpose: `git lfs push` needs them to
-          # upload the recorded snapshot objects before the commit is created.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Bot token, as in dhis2-android-capture-app: credentials are persisted
+          # so `git lfs push` can upload the recorded snapshot objects, and a bot
+          # commit (unlike a GITHUB_TOKEN one) still triggers CI.
+          token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
       - name: Set Up JDK
         uses: actions/setup-java@v5
@@ -63,85 +64,46 @@ jobs:
           name: paparazzi-golden-images
           path: ${{ env.main_project_module }}/src/androidUnitTest/snapshots/images
 
-      # Stages the recorded images and uploads their LFS objects. The commit
-      # made here is local only and never pushed -- it exists so `git lfs push`
-      # has a ref to walk, and so the pointer blobs land in the object store for
-      # the API commit below to read.
-      - name: Stage changes and upload LFS objects
-        id: stage
+      # gh-commit (like dhis2-android-capture-app) commits via the GitHub API, so
+      # the commit is signed with GitHub's web-flow key and counts as Verified --
+      # required because the "Require signed commits" ruleset covers ~ALL branches
+      # with no bypass actors, and a plain push of a bot commit is rejected (GH013).
+      #
+      # The catch: gh-commit reads file contents from the WORKING TREE
+      # (fs.readFileSync). The golden images are LFS-tracked, so the working tree
+      # holds real PNG bytes -- committing those would silently take the images out
+      # of LFS. So upload the LFS objects first, then replace the working-tree files
+      # with their pointer text, which is what actually belongs in the commit.
+      - name: Upload LFS objects and stage pointers
         if: steps.verify.outcome == 'failure'
         run: |
-          before=$(git rev-parse HEAD)
-          .github/workflows/scripts/commit-changes.sh
-          after=$(git rev-parse HEAD)
-          if [ "$before" = "$after" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No recorded image changes to commit."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            git lfs push origin HEAD
+          set -euo pipefail
+          git add -A
+          mapfile -t added < <(git diff --cached --name-only --diff-filter=d)
+          if [ ${#added[@]} -eq 0 ]; then
+            echo "No recorded image changes."
+            exit 0
           fi
+          # Push the LFS blobs before the pointers land, so the commit is never
+          # left referencing objects the server doesn't have.
+          oids=()
+          for f in "${added[@]}"; do
+            oid=$(git cat-file blob ":$f" | sed -n 's/^oid sha256://p')
+            if [ -n "$oid" ]; then oids+=("$oid"); fi
+          done
+          if [ ${#oids[@]} -gt 0 ]; then
+            git lfs push --object-id origin "${oids[@]}"
+          fi
+          # Hand gh-commit pointers instead of PNGs.
+          for f in "${added[@]}"; do
+            git cat-file blob ":$f" > "$f"
+          done
+          git reset
 
-      # The repository ruleset "Require signed commits" applies to ~ALL branches
-      # with no bypass actors, so a plain `git push` of a bot commit is rejected.
-      # Commits created through the API are signed by GitHub's web-flow key and
-      # count as Verified. LFS-tracked files must be sent as their *pointer*
-      # text -- the real bytes were uploaded by `git lfs push` above.
-      - name: Commit golden images via API (verified)
-        if: steps.verify.outcome == 'failure' && steps.stage.outputs.changed == 'true'
-        uses: actions/github-script@v7
+      - name: Commit golden images
+        if: steps.verify.outcome == 'failure'
+        uses: flex-development/gh-commit@177be4b5bca1b102400ca7220932d9ff7980fddb
         with:
-          script: |
-            const { execFileSync } = require('child_process');
-            const git = (...args) =>
-              execFileSync('git', args, { maxBuffer: 64 * 1024 * 1024 });
-            const gitText = (...args) => git(...args).toString().trim();
-
-            const branch = process.env.GITHUB_REF_NAME;
-            // Parent on the branch head as it is *now*, not on the commit this
-            // run checked out -- someone may have pushed while the snapshots
-            // were being recorded, and a stale parent makes updateRef fail with
-            // "Update is not a fast forward". Only the recorded images are
-            // applied on top, so re-parenting is safe.
-            const ref = await github.rest.git.getRef({
-              ...context.repo, ref: `heads/${branch}`,
-            });
-            const parent = ref.data.object.sha;
-            const names = gitText('diff', '--name-status', 'HEAD~1', 'HEAD');
-            if (!names) {
-              core.info('No changes to commit.');
-              return;
-            }
-
-            const tree = [];
-            for (const line of names.split('\n')) {
-              const [status, ...rest] = line.split('\t');
-              const path = rest[rest.length - 1];
-              if (status.startsWith('D')) {
-                tree.push({ path, mode: '100644', type: 'blob', sha: null });
-                continue;
-              }
-              // Raw stored blob: for LFS-tracked paths this is the pointer text.
-              const content = git('cat-file', 'blob', `HEAD:${path}`).toString('utf8');
-              const blob = await github.rest.git.createBlob({
-                ...context.repo, content, encoding: 'utf-8',
-              });
-              tree.push({ path, mode: '100644', type: 'blob', sha: blob.data.sha });
-            }
-
-            const parentCommit = await github.rest.git.getCommit({
-              ...context.repo, commit_sha: parent,
-            });
-            const newTree = await github.rest.git.createTree({
-              ...context.repo, base_tree: parentCommit.data.tree.sha, tree,
-            });
-            const commit = await github.rest.git.createCommit({
-              ...context.repo,
-              message: 'Paparazzi Golden Images',
-              tree: newTree.data.sha,
-              parents: [parent],
-            });
-            await github.rest.git.updateRef({
-              ...context.repo, ref: `heads/${branch}`, sha: commit.data.sha,
-            });
-            core.info(`Committed ${tree.length} file(s) as ${commit.data.sha}`);
+          message: 'Paparazzi Golden Images'
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/generate-paparazzi-golden-images.yml
+++ b/.github/workflows/generate-paparazzi-golden-images.yml
@@ -11,13 +11,16 @@ on:
 jobs:
   ci_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
           lfs: 'true'
           fetch-depth: 0
-          persist-credentials: false
+          # Credentials are persisted on purpose: `git lfs push` needs them to
+          # upload the recorded snapshot objects before the commit is created.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Up JDK
@@ -53,13 +56,92 @@ jobs:
         if: steps.verify.outcome == 'failure'
         run: ./gradlew ${{ env.main_project_module }}:verifyPaparazziDebug --no-daemon
 
-      - name: Commit Changes
+      - name: Upload recorded images as artifact
         if: steps.verify.outcome == 'failure'
-        run: .github/workflows/scripts/commit-changes.sh
-
-      - name: Push changes
-        if: steps.verify.outcome == 'failure'
-        uses: ad-m/github-push-action@master
+        uses: actions/upload-artifact@v7.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          name: paparazzi-golden-images
+          path: ${{ env.main_project_module }}/src/androidUnitTest/snapshots/images
+
+      # Stages the recorded images and uploads their LFS objects. The commit
+      # made here is local only and never pushed -- it exists so `git lfs push`
+      # has a ref to walk, and so the pointer blobs land in the object store for
+      # the API commit below to read.
+      - name: Stage changes and upload LFS objects
+        id: stage
+        if: steps.verify.outcome == 'failure'
+        run: |
+          before=$(git rev-parse HEAD)
+          .github/workflows/scripts/commit-changes.sh
+          after=$(git rev-parse HEAD)
+          if [ "$before" = "$after" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No recorded image changes to commit."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git lfs push origin HEAD
+          fi
+
+      # The repository ruleset "Require signed commits" applies to ~ALL branches
+      # with no bypass actors, so a plain `git push` of a bot commit is rejected.
+      # Commits created through the API are signed by GitHub's web-flow key and
+      # count as Verified. LFS-tracked files must be sent as their *pointer*
+      # text -- the real bytes were uploaded by `git lfs push` above.
+      - name: Commit golden images via API (verified)
+        if: steps.verify.outcome == 'failure' && steps.stage.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execFileSync } = require('child_process');
+            const git = (...args) =>
+              execFileSync('git', args, { maxBuffer: 64 * 1024 * 1024 });
+            const gitText = (...args) => git(...args).toString().trim();
+
+            const branch = process.env.GITHUB_REF_NAME;
+            // Parent on the branch head as it is *now*, not on the commit this
+            // run checked out -- someone may have pushed while the snapshots
+            // were being recorded, and a stale parent makes updateRef fail with
+            // "Update is not a fast forward". Only the recorded images are
+            // applied on top, so re-parenting is safe.
+            const ref = await github.rest.git.getRef({
+              ...context.repo, ref: `heads/${branch}`,
+            });
+            const parent = ref.data.object.sha;
+            const names = gitText('diff', '--name-status', 'HEAD~1', 'HEAD');
+            if (!names) {
+              core.info('No changes to commit.');
+              return;
+            }
+
+            const tree = [];
+            for (const line of names.split('\n')) {
+              const [status, ...rest] = line.split('\t');
+              const path = rest[rest.length - 1];
+              if (status.startsWith('D')) {
+                tree.push({ path, mode: '100644', type: 'blob', sha: null });
+                continue;
+              }
+              // Raw stored blob: for LFS-tracked paths this is the pointer text.
+              const content = git('cat-file', 'blob', `HEAD:${path}`).toString('utf8');
+              const blob = await github.rest.git.createBlob({
+                ...context.repo, content, encoding: 'utf-8',
+              });
+              tree.push({ path, mode: '100644', type: 'blob', sha: blob.data.sha });
+            }
+
+            const parentCommit = await github.rest.git.getCommit({
+              ...context.repo, commit_sha: parent,
+            });
+            const newTree = await github.rest.git.createTree({
+              ...context.repo, base_tree: parentCommit.data.tree.sha, tree,
+            });
+            const commit = await github.rest.git.createCommit({
+              ...context.repo,
+              message: 'Paparazzi Golden Images',
+              tree: newTree.data.sha,
+              parents: [parent],
+            });
+            await github.rest.git.updateRef({
+              ...context.repo, ref: `heads/${branch}`, sha: commit.data.sha,
+            });
+            core.info(`Committed ${tree.length} file(s) as ${commit.data.sha}`);

--- a/.github/workflows/generate-paparazzi-golden-images.yml
+++ b/.github/workflows/generate-paparazzi-golden-images.yml
@@ -19,10 +19,17 @@ jobs:
         with:
           lfs: 'true'
           fetch-depth: 0
-          # Bot token, as in dhis2-android-capture-app: credentials are persisted
-          # so `git lfs push` can upload the recorded snapshot objects, and a bot
-          # commit (unlike a GITHUB_TOKEN one) still triggers CI.
-          token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+          # Credentials are persisted on purpose: `git lfs push` needs them to
+          # upload the recorded snapshot objects before the commit is created.
+          #
+          # dhis2-android-capture-app uses DHIS2_BOT_GITHUB_TOKEN here, but that
+          # secret is not scoped to this repository (it resolves to empty and
+          # checkout fails with "Input required and not supplied: token").
+          # GITHUB_TOKEN works; the only cost is that commits it creates do not
+          # trigger workflows, so the resulting CI run waits for approval. If the
+          # bot secret is ever granted to this repo, swapping it in here and below
+          # removes that manual step.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Up JDK
         uses: actions/setup-java@v5
@@ -80,4 +87,4 @@ jobs:
         with:
           message: 'Paparazzi Golden Images'
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/commit-changes.sh
+++ b/.github/workflows/scripts/commit-changes.sh
@@ -1,8 +1,0 @@
-git config user.name "GitHub Actions Bot"
-git config user.email "<android@dhis2.org>"
-
-# Detects both modifications to tracked files and new untracked files (e.g. newly recorded Paparazzi images)
-if [ -n "$(git status --porcelain)" ]; then
-  git add -A
-  git commit -m "Paparazzi Golden Images"
-fi

--- a/.github/workflows/scripts/stage-golden-images.sh
+++ b/.github/workflows/scripts/stage-golden-images.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Prepares freshly recorded Paparazzi golden images for flex-development/gh-commit.
+#
+# gh-commit builds the commit through the GitHub API, so it is signed with GitHub's
+# web-flow key and satisfies the "Require signed commits" ruleset that rejects a
+# plain bot push (GH013). It does NOT make a local commit -- it reads the changed
+# files straight from the working tree (fs.readFileSync in changes.handler.ts), so
+# this script must leave the changes uncommitted for it to find them.
+#
+# The wrinkle: the golden images are LFS-tracked, so the working tree holds real
+# PNG bytes. Letting gh-commit read those would commit ~1 MB of PNGs directly into
+# git and silently take the images out of LFS, while appearing to succeed. So the
+# LFS objects are uploaded here and the working-tree files are replaced with their
+# pointer text, which is what actually belongs in the commit.
+set -euo pipefail
+
+git add -A
+
+# Deletions are excluded: they have no index blob to read, and gh-commit picks them
+# up from `git status` on its own.
+changed=$(git diff --cached --name-only --diff-filter=d)
+if [ -z "$changed" ]; then
+  echo "No recorded image changes."
+  exit 0
+fi
+
+# Upload the blobs before the pointers land, so the commit is never left
+# referencing objects the server does not have. Kept POSIX-ish on purpose:
+# `mapfile` would restrict this to bash 4+ and make it untestable on macOS.
+oids=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  oid=$(git cat-file blob ":$f" | sed -n 's/^oid sha256://p')
+  if [ -n "$oid" ]; then oids="$oids $oid"; fi
+done <<EOF
+$changed
+EOF
+
+if [ -n "$oids" ]; then
+  echo "Uploading LFS object(s):$oids"
+  # Word splitting is intended -- sha256 hex ids never contain spaces.
+  # shellcheck disable=SC2086
+  git lfs push --object-id origin $oids
+fi
+
+# Hand gh-commit pointer text rather than PNG bytes.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  git cat-file blob ":$f" > "$f"
+done <<EOF
+$changed
+EOF
+
+# Unstage: gh-commit reads the working tree, not the index.
+git reset
+echo "Staged $(printf '%s\n' "$changed" | wc -l | tr -d ' ') file(s) as LFS pointers."


### PR DESCRIPTION
Draft. Independent of any dependency upgrade — this workflow is currently broken on **every** branch.

## Problem

The org ruleset **"Require signed commits"** (`17215510`, shared with dhis2-android-capture-app) applies to `~ALL` branches with **no bypass actors**. This workflow commits as `GitHub Actions Bot` and pushes with `ad-m/github-push-action`, producing an unsigned commit, so the push is rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/...
remote: - Commits must have verified signatures.
 ! [remote rejected] HEAD -> ... (push declined due to repository rule violations)
```

Recording and re-verification work fine — only the push fails. The last golden images this workflow landed (`d7ffbc4`, `b742959`) are unsigned and predate the ruleset, which is why it went unnoticed: the workflow simply cannot be used any more.

## Fix

Adopt the same approach as **dhis2-android-capture-app**: commit with [`flex-development/gh-commit`](https://github.com/flex-development/gh-commit), pinned to the same SHA it uses. The action commits through the GitHub API, so the commit is signed with GitHub's web-flow key and counts as Verified — no bypass actor required.

Two places this repo differs from capture-app, both discovered the hard way:

### 1. LFS

Capture-app LFS-tracks nothing (no `.gitattributes`, 0 tracked files). This repo LFS-tracks the 34 golden images, and gh-commit reads contents from the **working tree**:

```ts
// src/queries/changes.handler.ts:84
contents: fs.readFileSync(file, 'base64'),
```

For an LFS path the working tree holds the real PNG bytes, so using the action unmodified would commit ~1 MB of PNGs directly into git and silently take all 34 images out of LFS — while appearing to succeed:

```
working tree : 89 50 4e 47 0d 0a 1a 0a        <- .PNG, what fs.readFileSync sees
index blob   : version https://git-lfs.github.com/spec/v1
               oid sha256:6ac303fd…           <- what belongs in the commit
```

`scripts/stage-golden-images.sh` therefore uploads the LFS objects and replaces the working-tree files with their pointer text before the action runs. It replaces `commit-changes.sh`, whose job no longer exists — that script made a local commit so `git push` had something to push, but gh-commit needs the changes left *uncommitted* in the working tree, so a local commit would leave it nothing to find.

### 2. Token

`DHIS2_BOT_GITHUB_TOKEN` is **not scoped to this repository** — it resolves to empty and checkout fails with `Input required and not supplied: token`. `GITHUB_TOKEN` works, with `contents: write` granted to the job. The only cost: commits created with `GITHUB_TOKEN` don't trigger workflows, so the CI run for a regenerated-goldens commit waits for approval. If that secret is ever granted to this repo, swapping it in is a two-line change and removes the manual step.

Also uploads the recorded images as a `paparazzi-golden-images` artifact so they can be reviewed without pulling the branch.

## Verified end to end

Run on a scratch branch carrying the Compose upgrade with the golden images rolled back to develop's versions, so `verifyPaparazziDebug` genuinely failed and the whole path executed ([run 30992286437](https://github.com/dhis2/dhis2-mobile-ui/actions/runs/30992286437)):

| check | result |
|---|---|
| every step | ✅ verify-fails → record → revalidate → artifact → LFS upload → stage → commit |
| ruleset accepted the commit | ✅ `verified=true`, `reason=valid` |
| committed as LFS pointers, not PNG bytes | ✅ 34/34 |
| reproduces the known-good goldens exactly | ✅ 34/34 oids identical |

The last row also shows this produces byte-identical results to the hand-rolled API commit it replaces, and that Paparazzi rendering is reproducible across runs.

`stage-golden-images.sh` is separately tested against a scratch LFS repo covering a modified image, a new image, a deleted image and a non-LFS file. It deliberately avoids `mapfile` so it runs on bash 3.2 as well as the runner's bash 5 — the first version used it and failed locally, leaving raw PNG bytes staged, which would only have surfaced on a macOS runner.

**Not exercised:** a genuine first-time LFS upload. The objects already existed on the server, so `git lfs push --object-id` was a no-op. The command path runs, but new-blob upload is unproven.

## Note

`java-version` is deliberately untouched. The companion upgrade PR #568 raises it, and the two changes sit in different parts of the file, so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
